### PR TITLE
Fix parsing of longs near MIN/MAX_INT, parsing of BigIntegers.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -529,7 +529,7 @@ public class YAMLParser
                 return null;
             }
         } else {
-            _numberNegative = true;
+            _numberNegative = false;
             i = 0;
         }
         while (true) {
@@ -675,8 +675,16 @@ public class YAMLParser
             }
             // !!! TODO: implement proper bounds checks; now we'll just use BigInteger for convenience
             try {
-                _numberBigInt = new BigInteger(_textValue);
+                BigInteger n = new BigInteger(_textValue);
+                // Could still fit in a long, need to check
+                if (len == 19 && n.bitLength() <= 63) {
+                    _numberLong = n.longValue();
+                    _numTypesValid = NR_LONG;
+                    return;
+                }
+                _numberBigInt = n;
                 _numTypesValid = NR_BIGINT;
+                return;
             } catch (NumberFormatException nex) {
                 // Can this ever occur? Due to overflow, maybe?
                 _wrapError("Malformed numeric value '"+_textValue+"'", nex);

--- a/src/test/java/com/fasterxml/jackson/dataformat/yaml/SimpleParseTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/yaml/SimpleParseTest.java
@@ -3,12 +3,118 @@ package com.fasterxml.jackson.dataformat.yaml;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
+import java.math.BigInteger;
+
 /**
  * Unit tests for checking functioning of the underlying
  * parser implementation.
  */
 public class SimpleParseTest extends ModuleTestBase
 {
+    // Parsing large numbers around the transition from int->long and long->BigInteger
+    public void testIntParsing() throws Exception
+    {
+        YAMLFactory f = new YAMLFactory();
+        String YAML;
+        JsonParser jp;
+
+        // Test positive max-int
+        YAML = "num: 2147483647";
+        jp = f.createJsonParser(YAML);
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        assertToken(JsonToken.FIELD_NAME, jp.nextToken());
+        assertEquals("num", jp.getCurrentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, jp.nextToken());
+        assertEquals(Integer.MAX_VALUE, jp.getIntValue());
+        assertEquals(JsonParser.NumberType.INT, jp.getNumberType());
+        assertEquals("2147483647", jp.getText());
+        jp.close();
+
+        // Test negative max-int
+        YAML = "num: -2147483648";
+        jp = f.createJsonParser(YAML);
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        assertToken(JsonToken.FIELD_NAME, jp.nextToken());
+        assertEquals("num", jp.getCurrentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, jp.nextToken());
+        assertEquals(Integer.MIN_VALUE, jp.getIntValue());
+        assertEquals(JsonParser.NumberType.INT, jp.getNumberType());
+        assertEquals("-2147483648", jp.getText());
+        jp.close();
+
+        // Test positive max-int + 1
+        YAML = "num: 2147483648";
+        jp = f.createJsonParser(YAML);
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        assertToken(JsonToken.FIELD_NAME, jp.nextToken());
+        assertEquals("num", jp.getCurrentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, jp.nextToken());
+        assertEquals(Integer.MAX_VALUE + 1L, jp.getLongValue());
+        assertEquals(JsonParser.NumberType.LONG, jp.getNumberType());
+        assertEquals("2147483648", jp.getText());
+        jp.close();
+
+        // Test negative max-int - 1
+        YAML = "num: -2147483649";
+        jp = f.createJsonParser(YAML);
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        assertToken(JsonToken.FIELD_NAME, jp.nextToken());
+        assertEquals("num", jp.getCurrentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, jp.nextToken());
+        assertEquals(Integer.MIN_VALUE - 1L, jp.getLongValue());
+        assertEquals(JsonParser.NumberType.LONG, jp.getNumberType());
+        assertEquals("-2147483649", jp.getText());
+        jp.close();
+
+        // Test positive max-long
+        YAML = "num: 9223372036854775807";
+        jp = f.createJsonParser(YAML);
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        assertToken(JsonToken.FIELD_NAME, jp.nextToken());
+        assertEquals("num", jp.getCurrentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, jp.nextToken());
+        assertEquals(Long.MAX_VALUE, jp.getLongValue());
+        assertEquals(JsonParser.NumberType.LONG, jp.getNumberType());
+        assertEquals("9223372036854775807", jp.getText());
+        jp.close();
+
+        // Test negative max-long
+        YAML = "num: -9223372036854775808";
+        jp = f.createJsonParser(YAML);
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        assertToken(JsonToken.FIELD_NAME, jp.nextToken());
+        assertEquals("num", jp.getCurrentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, jp.nextToken());
+        assertEquals(Long.MIN_VALUE, jp.getLongValue());
+        assertEquals(JsonParser.NumberType.LONG, jp.getNumberType());
+        assertEquals("-9223372036854775808", jp.getText());
+        jp.close();
+
+        // Test positive max-long + 1
+        YAML = "num: 9223372036854775808";
+        jp = f.createJsonParser(YAML);
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        assertToken(JsonToken.FIELD_NAME, jp.nextToken());
+        assertEquals("num", jp.getCurrentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, jp.nextToken());
+        assertEquals(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE), jp.getBigIntegerValue());
+        assertEquals(JsonParser.NumberType.BIG_INTEGER, jp.getNumberType());
+        assertEquals("9223372036854775808", jp.getText());
+        jp.close();
+
+        // Test negative max-long - 1
+        YAML = "num: -9223372036854775809";
+        jp = f.createJsonParser(YAML);
+        assertToken(JsonToken.START_OBJECT, jp.nextToken());
+        assertToken(JsonToken.FIELD_NAME, jp.nextToken());
+        assertEquals("num", jp.getCurrentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, jp.nextToken());
+        assertEquals(BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE), jp.getBigIntegerValue());
+        assertEquals(JsonParser.NumberType.BIG_INTEGER, jp.getNumberType());
+        assertEquals("-9223372036854775809", jp.getText());
+        jp.close();
+    }
+
     // [Issue-4]: accidental recognition as double, with multiple dots
     public void testDoubleParsing() throws Exception
     {


### PR DESCRIPTION
This fixes a few bugs in the parsing of large numbers:

Parsing of 10-digit `long` values fails with the following stack trace using `new ObjectMapper(new YAMLFactory()).readTree("2147483648");`:

```
Exception in thread "main" java.lang.NumberFormatException: For input string: "2147483648"
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:48)
    at java.lang.Integer.parseInt(Integer.java:465)
    at java.lang.Integer.parseInt(Integer.java:499)
    at com.fasterxml.jackson.dataformat.yaml.YAMLParser._parseNumericValue(YAMLParser.java:644)
```

Parsing of `BigInteger` values fails with the following stack trace using `new ObjectMapper(new YAMLFactory()).readTree("19223372036854775807");`:

```
Exception in thread "main" com.fasterxml.jackson.core.JsonParseException: Current token (VALUE_NUMBER_INT) not numeric, can not use numeric value accessors
 at [Source: java.io.StringReader@15e232b5; line: 1, column: 21]
    at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1378)
    at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:599)
    at com.fasterxml.jackson.dataformat.yaml.YAMLParser._parseNumericValue(YAMLParser.java:697)
    at com.fasterxml.jackson.core.base.ParserBase.getNumberType(ParserBase.java:599)
```
