### PR TITLE
Reverting project java dependency back version 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@ abstractions.
   <properties>
     <jackson.core.version>2.2.0-SNAPSHOT</jackson.core.version>
     <jackson.annotations.version>2.2.0-SNAPSHOT</jackson.annotations.version>
-    <javac.src.version>1.6</javac.src.version>
-    <javac.target.version>1.6</javac.target.version>
+    <javac.src.version>1.5</javac.src.version>
+    <javac.target.version>1.5</javac.target.version>
     <packageVersion.dir>com/fasterxml/jackson/dataformat/yaml</packageVersion.dir>
     <packageVersion.package>com.fasterxml.jackson.dataformat.yaml</packageVersion.package>
 

--- a/src/main/java/com/fasterxml/jackson/dataformat/yaml/PackageVersion.java.in
+++ b/src/main/java/com/fasterxml/jackson/dataformat/yaml/PackageVersion.java.in
@@ -13,7 +13,7 @@ public final class PackageVersion implements Versioned {
     public final static Version VERSION = VersionUtil.parseVersion(
         "@projectversion@", "@projectgroupid@", "@projectartifactid@");
 
-    @Override
+    //@Override
     public Version version() {
         return VERSION;
     }

--- a/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -1,19 +1,34 @@
 package com.fasterxml.jackson.dataformat.yaml;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.Collections;
 
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.emitter.Emitter;
-import org.yaml.snakeyaml.events.*;
+import org.yaml.snakeyaml.events.DocumentEndEvent;
+import org.yaml.snakeyaml.events.DocumentStartEvent;
+import org.yaml.snakeyaml.events.ImplicitTuple;
+import org.yaml.snakeyaml.events.MappingEndEvent;
+import org.yaml.snakeyaml.events.MappingStartEvent;
+import org.yaml.snakeyaml.events.ScalarEvent;
+import org.yaml.snakeyaml.events.SequenceEndEvent;
+import org.yaml.snakeyaml.events.SequenceStartEvent;
+import org.yaml.snakeyaml.events.StreamEndEvent;
+import org.yaml.snakeyaml.events.StreamStartEvent;
 
-import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.FormatSchema;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.core.base.GeneratorBase;
-import com.fasterxml.jackson.core.json.JsonWriteContext;
 import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.json.JsonWriteContext;
 
 public class YAMLGenerator extends GeneratorBase
 {
@@ -408,7 +423,7 @@ public class YAMLGenerator extends GeneratorBase
         _verifyValueWrite("write Binary value");
         // ok, better just Base64 encode as a String...
         if (offset > 0 || (offset+len) != data.length) {
-            data = Arrays.copyOfRange(data, offset, offset+len);
+            data = _copyOfRange(data, offset, offset+len);
         }
         String encoded = b64variant.encode(data);
         _writeScalar(encoded, "byte[]", STYLE_BASE64);
@@ -541,5 +556,15 @@ public class YAMLGenerator extends GeneratorBase
         // 'type' can be used as 'tag'... but should we?
         return new ScalarEvent(null, null, DEFAULT_IMPLICIT, value,
                 null, null, style);
+    }
+    
+    private static byte[] _copyOfRange(byte[] original, int from, int to) {
+        int newLength = to - from;
+        if (newLength < 0)
+            throw new IllegalArgumentException(from + " > " + to);
+        byte[] copy = new byte[newLength];
+        System.arraycopy(original, from, copy, 0,
+                         Math.min(original.length - from, newLength));
+        return copy;
     }
 }


### PR DESCRIPTION
First of all, thanks for your efforts with this library, I like it a lot! I'm new to both git and github so I hope you forgive me if I haven't followed protocol, I figured this was the way to go that would be the least trouble on your part if you were interested. My environment forces me to use java 1.5, and all other jackson libraries I need can be compiled that way, with the exception of this one. I figure others might have that problem, and this would be an innocent fix to do so. I hope you will consider it for inclusion. Thanks in advance!

Modification summary:
Included one snippet from J2SE-1.6 in YAMLGenerator such that the whole
project can actually compile with 1.5.

Also commented an @override annotation in PackageVersion that
for some reason did not want to play nice since reverting back to
JDK 1.5.
