### PR TITLE
Change build to not use shading for including SnakeYAML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>com.fasterxml</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>10</version>
+    <version>11</version>
   </parent>
 
   <groupId>com.fasterxml.jackson.dataformat</groupId>
   <artifactId>jackson-dataformat-yaml</artifactId>
   <version>2.2.3-SNAPSHOT</version>
-
   <name>Jackson-dataformat-YAML</name>
+  <packaging>bundle</packaging>
   <description>Support for reading and writing YAML-encoded data via Jackson
 abstractions.
   </description>


### PR DESCRIPTION
This pull request removes shading of snakeyaml. Snake YAML is now osgi bundle. In regular J2SE applications users should handle dependency management on their own.
