### PR TITLE
Remove unecessary imports of snakeyaml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,6 @@
 
     <osgi.export>${project.groupId}.yaml;version=${project.version}</osgi.export>
     <osgi.import>
-org.yaml.snakeyaml,
-org.yaml.snakeyaml.emitter,
-org.yaml.snakeyaml.error,
-org.yaml.snakeyaml.events,
-org.yaml.snakeyaml.parser,
-org.yaml.snakeyaml.reader,
 com.fasterxml.jackson.core,
 com.fasterxml.jackson.core.base,
 com.fasterxml.jackson.core.format,


### PR DESCRIPTION
Different approach to solve osgi issues. I checked parser alone and it does work under OSGi without any issues. Please test if local build is stable as maven-shade-plugin + maven-bundle-plugin sometimes do not play well together.
