### PR TITLE
Fix a broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-This project contains [Jackson](http://http://wiki.fasterxml.com/JacksonHome) extension component for reading and writing [YAML](http://en.wikipedia.org/wiki/YAML) encoded data.
+This project contains [Jackson](http://wiki.fasterxml.com/JacksonHome) extension component for reading and writing [YAML](http://en.wikipedia.org/wiki/YAML) encoded data.
 [SnakeYAML](http://code.google.com/p/snakeyaml/) library is used for low-level YAML parsing.
 This project adds necessary abstractions on top to make things work with other Jackson functionality.
 


### PR DESCRIPTION
The first link in the README file contains one "http://" too many. This kills the link. 