### PR TITLE
Add MINIMIZE_QUOTES generator feature

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.core.io.IOContext;
 
 public class YAMLGenerator extends GeneratorBase
 {
+
+
     /**
      * Enumeration that defines all togglable features for YAML generators
      */
@@ -66,7 +68,18 @@ public class YAMLGenerator extends GeneratorBase
          *
          * @since 2.6
          */
-        SPLIT_LINES(true)
+        SPLIT_LINES(true),
+
+        /**
+         * Whether strings will be rendered without quotes (true) or
+         * with quotes (false, default).
+         *<p>
+         * Minimized quote usage makes for more human readable output; however, content is
+         * limited to printable characters according to the rules of
+         * <a href="http://www.yaml.org/spec/1.2/spec.html#style/block/literal">literal block style</a>.
+         * @since 2.6
+         */
+        MINIMIZE_QUOTES(false)
         
         ;
 
@@ -126,10 +139,14 @@ public class YAMLGenerator extends GeneratorBase
     // numbers, booleans, should use implicit
     private final static Character STYLE_SCALAR = null;
     // Strings quoted for fun
-    private final static Character STYLE_STRING = Character.valueOf('"');
-        
+    private final static Character STYLE_QUOTED = Character.valueOf('"');
+    // Strings in literal (block) style
+    private final static Character STYLE_LITERAL = Character.valueOf('|');
+
     // Which flow style to use for Base64? Maybe basic quoted?
     private final static Character STYLE_BASE64 = Character.valueOf('"');
+
+    private final static Character STYLE_PLAIN = null;
 
     /*
     /**********************************************************
@@ -439,7 +456,16 @@ public class YAMLGenerator extends GeneratorBase
             return;
         }
         _verifyValueWrite("write String value");
-        _writeScalar(text, "string", STYLE_STRING);
+        Character style = STYLE_QUOTED;
+        if (Feature.MINIMIZE_QUOTES.enabledIn(_formatFeatures)) {
+            if (text.contains("\n")) {
+                style = STYLE_LITERAL;
+            }
+            else {
+                style = STYLE_PLAIN;
+            }
+        }
+        _writeScalar(text, "string", style);
     }
 
     @Override

--- a/src/test/java/com/fasterxml/jackson/dataformat/yaml/SimpleGenerationTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/yaml/SimpleGenerationTest.java
@@ -192,6 +192,42 @@ public class SimpleGenerationTest extends ModuleTestBase
                 yaml);
     }    
 
+    public void testLiteralStringsSingleLine() throws Exception
+    {
+        YAMLFactory f = new YAMLFactory();
+        // verify default settings
+        assertFalse(f.isEnabled(YAMLGenerator.Feature.MINIMIZE_QUOTES));
+
+        f.configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true);
+
+        YAMLMapper mapper = new YAMLMapper(f);
+
+        Map<String, Object> content = new HashMap<String, Object>();
+        content.put("key", "some value");
+        String yaml = mapper.writeValueAsString(content).trim();
+
+        assertEquals("---\n" +
+                "key: some value", yaml);
+    }
+
+    public void testLiteralStringsMultiLine() throws Exception
+    {
+        YAMLFactory f = new YAMLFactory();
+        // verify default settings
+        assertFalse(f.isEnabled(YAMLGenerator.Feature.MINIMIZE_QUOTES));
+
+        f.configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true);
+
+        YAMLMapper mapper = new YAMLMapper(f);
+
+        Map<String, Object> content = new HashMap<String, Object>();
+        content.put("key", "first\nsecond\nthird");
+        String yaml = mapper.writeValueAsString(content).trim();
+
+        assertEquals("---\n" +
+                "key: |-\n  first\n  second\n  third", yaml);
+    }
+
     /*
     /**********************************************************************
     /* Helper methods


### PR DESCRIPTION
One of the reasons I like yaml is the option to use very little quoting...so, selfishly, I wanted a `YAMLGenerator` feature to enable output that looks more like:

```
short: one line content
long: |
  line 1
  line 2
```

I left the default behavior as it is now, to use quoted string scalar style.

Please let me know if there are any associated changes, such as documentation, that you would like me to make.