### PR TITLE
Allow multiple UTF8Readers to be used in the same thread at the same time

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/yaml/UTF8Reader.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/yaml/UTF8Reader.java
@@ -69,7 +69,9 @@ public final class UTF8Reader
         _bufferHolder = _findBufferHolder();
         byte[] buffer = _bufferHolder[0];
         if (buffer == null) {
-            _bufferHolder[0] = buffer = new byte[DEFAULT_BUFFER_SIZE];
+            buffer = new byte[DEFAULT_BUFFER_SIZE];
+        } else {
+            _bufferHolder[0] = null;
         }
         _inputBuffer = buffer;
         _inputPtr = 0;

--- a/src/test/java/com/fasterxml/jackson/dataformat/yaml/UTF8ReaderTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/yaml/UTF8ReaderTest.java
@@ -1,0 +1,34 @@
+package com.fasterxml.jackson.dataformat.yaml;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class UTF8ReaderTest {
+
+    @Test
+    public void canUseMultipleUTF8ReadersInSameThread() throws IOException {
+        String message = "we expect this message to be present after reading the contents of the reader out";
+        InputStream expected = new ByteArrayInputStream(("." + message).getBytes(StandardCharsets.UTF_8));
+        InputStream overwriter =
+                new ByteArrayInputStream(".in older versions of Jackson, this overwrote it"
+                        .getBytes(StandardCharsets.UTF_8));
+
+        char[] result = new char[message.length()];
+
+        UTF8Reader utf8Reader = new UTF8Reader(expected, true);
+        UTF8Reader badUtf8Reader = new UTF8Reader(overwriter, true);
+
+        utf8Reader.read();
+        badUtf8Reader.read();
+
+        utf8Reader.read(result);
+
+        assertEquals(message, new String(result));
+    }
+}


### PR DESCRIPTION
Fixes #70.

There's currently a bug where UTF8Readers that exist concurrently in the
same thread overwrite each other, because they improperly share buffers.
This is clearly a bug; freeBuffers is kinda a no-op.

This PR modifies UTF8Reader to avoid this (I *think*, first time looking at the
code, could do with some more eyes).

When we take the buffer, we set it to null, and replace it when we free
the buffers. This means that people who use the class in the same
thread merely create a new buffer, which is a concern of performance and
not of correctness